### PR TITLE
chore: 도커파일 업데이트

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -37,14 +37,14 @@ services:
             - MYSQL_DATABASE=${DB_NAME}
             - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
             - TZ=Asia/Seoul
-            - PG_DATA=/var/lib/postgresql/data
+            - MS_DATA=/var/lib/mysql/data
         command:
             - --character-set-server=utf8mb4
             - --collation-server=utf8mb4_unicode_ci
         volumes:
-            - pgdata:/var/lib/mysql
+            - msdata:/var/lib/mysql
 
 networks:
     webnet:
 volumes:
-    pgdata:
+    msdata:


### PR DESCRIPTION
## Chore

- 배경
  - `server/docker-compose.yml` 파에서 40번줄이 
  `PG_DATA=/var/lib/postgre/data`로 되어있더라구요
  제가 레퍼런스를 참고할때 생각없이 관련코드를 작성한것 같은데,
  mysql로 변경하겠습니다.
  작동에는 영향을 주진 않는것으로 보입니다 
- 목적
 
## 과정
`PG_DATA=/var/lib/postgre/data` -> `MS_DATA=/var/lib/mysql/data`

## 결과 (스크린샷 등)

## 관련 issue 번호 (링크)

## 테스트 방법

## Commit
446cc12