### PR TITLE
feat/loginpage : 로그인페이지 퍼블리싱 및 버그픽스

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,17 @@
 import React from "react";
 import SignUp from "#pages/SignUp";
+import Login from "#pages/Login";
+import MainPage from "#pages/MainPage";
+import { Route, Routes } from "react-router-dom";
 
 function App() {
-    return <SignUp />;
+    return (
+        <Routes>
+            <Route path="/" element={<MainPage />} />
+            <Route path="signup" element={<SignUp />} />
+            <Route path="login" element={<Login />} />
+        </Routes>
+    );
 }
 
 export default App;

--- a/client/src/pages/Login.styles.ts
+++ b/client/src/pages/Login.styles.ts
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+import { COLOR } from "styles/color";
+
+export const LogoWrapper = styled.div`
+    color: ${COLOR.BLACK};
+    width: 90%;
+    height: 29px;
+    font-size: 2.4rem;
+    font-weight: bold;
+    font-family: "Noto Sans KR";
+    margin: auto;
+    margin-top: 10rem;
+    padding: 5rem;
+    text-align: center;
+`;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import Header from "#components/Header/Header";
+import Input from "#components/Input/Input";
+import Button from "#components/Button/Button";
+import useInput from "#hooks/useInput";
+import axios from "axios";
+import { PLACEHOLDER } from "#constants/constants";
+import { idValidator, passwordValidator } from "#utils/valitationUtils";
+
+import { InputWrapper, OptionsWrapper } from "./SignUp.styles";
+
+import { LogoWrapper } from "./Login.styles";
+
+const Login = () => {
+    const [userId, onChangeUserId, userIdError] = useInput(idValidator);
+    const [password, onChangePassword, passwordError] = useInput(passwordValidator);
+
+    const navigate = useNavigate();
+
+    const checkFormValidation = useCallback(() => {
+        return userIdError || passwordError;
+    }, [userIdError, passwordError]);
+
+    const onSubmitLogin = () => {
+        if (checkFormValidation()) return;
+        axios
+            .post("http://localhost:4000/auth/login", {
+                userId: userId,
+                password: password,
+            })
+            .then((res) => res.status === 201 && navigate("/", { replace: true }))
+            .catch(console.log);
+    };
+
+    return (
+        <>
+            <Header text="로그인" />
+            <LogoWrapper>RunWithMe</LogoWrapper>
+            <InputWrapper>
+                <Input placeholder={PLACEHOLDER.ID} type="text" onChange={onChangeUserId}></Input>
+                <span>{userIdError}</span>
+                <Input placeholder={PLACEHOLDER.PASSWORD} type="password" onChange={onChangePassword}></Input>
+                <span>{passwordError}</span>
+                <Button width="fill" onClick={onSubmitLogin}>
+                    로그인
+                </Button>
+            </InputWrapper>
+            <OptionsWrapper>
+                <div>
+                    <span onClick={() => navigate("/pwInquiry")}>비밀번호 찾기</span>
+                </div>
+                <div>
+                    <span onClick={() => navigate("/signup")}>회원가입</span>
+                </div>
+            </OptionsWrapper>
+        </>
+    );
+};
+
+export default Login;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -26,8 +26,8 @@ const Login = () => {
         if (checkFormValidation()) return;
         axios
             .post("http://localhost:4000/auth/login", {
-                userId: userId,
-                password: password,
+                userId,
+                password,
             })
             .then((res) => res.status === 201 && navigate("/", { replace: true }))
             .catch(console.log);

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+/*
+ 임시 메인페이지입니다 (라우팅 / 내비게이션 테스팅용)
+ */
+const MainPage = () => {
+    const navigate = useNavigate();
+    const handleLoginClick = () => {
+        navigate("/login");
+    };
+    const handleSignUpClick = () => {
+        navigate("/signup");
+    };
+
+    return (
+        <>
+            <button onClick={handleLoginClick}>로그인</button>
+            <button onClick={handleSignUpClick}>회원가입 </button>
+        </>
+    );
+};
+
+export default MainPage;

--- a/client/src/pages/SignUp.styles.ts
+++ b/client/src/pages/SignUp.styles.ts
@@ -41,16 +41,18 @@ export const OptionsWrapper = styled.div`
     color: grey;
     display: flex;
     margin: auto;
-    width: 60%;
+    width: 90%;
+    padding: 0 10rem;
 
     div {
+        display: flex;
         justify-content: center;
         flex-grow: 1;
         padding: 0.1rem 0.9rem;
         cursor: pointer;
     }
 
-    div:first-child {
+    div:not(:last-child) {
         border-right: 0.1rem solid grey;
     }
 `;

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -24,7 +24,7 @@ const SignUp = () => {
         return userIdError || passwordError || confirmPasswordError || !confirmPassword;
     }, [userIdError, passwordError, confirmPasswordError]);
 
-    const onSubmit = () => {
+    const onSubmitSignUp = () => {
         if (checkFormValidation()) return;
         axios
             .post("http://localhost:4000/user", {
@@ -55,13 +55,17 @@ const SignUp = () => {
                 <Input placeholder={PLACEHOLDER.PACE} type="number" onChange={onChangePace}></Input>
                 <Input placeholder={PLACEHOLDER.ZIP_CODE} type="number" onChange={onChangeZipCode}></Input>
                 <span>{zipCodeError}</span>
-                <Button width="fill" onClick={onSubmit}>
+                <Button width="fill" onClick={onSubmitSignUp}>
                     회원가입
                 </Button>
             </InputWrapper>
             <OptionsWrapper>
-                <div onClick={() => navigate("/pwInquiry")}>비밀번호 찾기</div>
-                <div onClick={() => navigate("/login")}>로그인 하기</div>
+                <div>
+                    <span onClick={() => navigate("/pwInquiry")}>비밀번호 찾기</span>
+                </div>
+                <div>
+                    <span onClick={() => navigate("/login")}>로그인 하기</span>
+                </div>
             </OptionsWrapper>
         </>
     );

--- a/client/src/utils/valitationUtils.ts
+++ b/client/src/utils/valitationUtils.ts
@@ -1,15 +1,15 @@
 export const idValidator = (id: string) => {
-    if (id.length >= 6 && id.length <= 20) return "";
     if (!id.length) return "ID를 입력해 주세요";
+    if (!(id.length >= 6 && id.length <= 20)) return "ID는 6자 이상 20자 이하여야 합니다";
     if (!/^[a-zA-Z0-9]*$/g.test(id)) return "영문 대소문자, 숫자만 입력이 가능합니다";
-    return "ID는 6자 이상 20자 이하여야 합니다";
+    return "";
 };
 
 export const passwordValidator = (password: string) => {
     return password.length < 10 || password.length > 100 ? "비밀번호는 10자 이상 100자 이하여야 합니다" : "";
 };
 export const confirmPasswordValidator = (password: string) => (confirmPassword: string) => {
-    return password !== confirmPassword || !confirmPassword ? "비밀번호를 한번 더 입력하세요" : "";
+    return password !== confirmPassword || !confirmPassword ? "비밀번호가 일치하지 않습니다" : "";
 };
 
 export const zipCodeValidator = (zipCode: string) => {


### PR DESCRIPTION
## Feature
로그인페이지 퍼블리싱
- 배경
  - 로그인페이지 퍼블리싱
- 목적
  - 로그인페이지 퍼블리싱

## 작업내용
- 임시로 **라우팅페이지**를 만들었습니다( localhost:3000이 좀 허전해서요)
- 화면을 좌우로 늘렸을 때 가운데 구분선이 한쪽으로 붙어서 개선했습니다
![image](https://user-images.githubusercontent.com/53655119/202835998-1b3da87b-1f30-4504-9257-746dacf9abca.png)
- `div `구조상 `cursor pointer`가 전체에 걸려있어서 글자가 아닌 부분에도 클릭하면 반응했는데,
 글자에만 클릭되도록 수정했습니다
- `InputValidator` 버그를 수정했습니다 (#33)
- 구분선이 scale 가능하도록 `first-child` 에서 `:not(:last-child)`로 변경했습니다
- 비밀번호 확인 에러문구를 수정했습니다 `비밀번호를 한번 더 입력하세요` -> `비밀번호가 일치하지 않습니다`
 
## 결과 (스크린샷 등)
![image](https://user-images.githubusercontent.com/53655119/202836172-d239b66b-a1ae-4806-abf0-62d499d992c9.png)

## 관련 issue 번호 (링크)
- #31 
- #33 

## 테스트 방법

## Commit
