### PR TITLE
feat: 모집 상세 페이지 퍼블리싱

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
                 "@types/node": "^16.18.3",
                 "@types/react": "^18.0.25",
                 "@types/react-dom": "^18.0.8",
+                "@types/recoil": "^0.0.9",
                 "axios": "^1.1.3",
                 "concurrently": "^7.5.0",
                 "react": "^18.2.0",
@@ -11288,6 +11289,15 @@
             "integrity": "sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==",
             "dependencies": {
                 "@types/react": "*"
+            }
+        },
+        "node_modules/@types/recoil": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/@types/recoil/-/recoil-0.0.9.tgz",
+            "integrity": "sha512-dXKcvdzQbkFCcULgxhtc/3shoCNqsspRUY1KwIUYcAzgS0qY7+IxlcjRjq+9PizFnzKrHESllkbezqCMstPmQA==",
+            "deprecated": "This is a stub types definition. recoil provides its own type definitions, so you do not need this installed.",
+            "dependencies": {
+                "recoil": "*"
             }
         },
         "node_modules/@types/resolve": {
@@ -40479,6 +40489,14 @@
             "integrity": "sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==",
             "requires": {
                 "@types/react": "*"
+            }
+        },
+        "@types/recoil": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/@types/recoil/-/recoil-0.0.9.tgz",
+            "integrity": "sha512-dXKcvdzQbkFCcULgxhtc/3shoCNqsspRUY1KwIUYcAzgS0qY7+IxlcjRjq+9PizFnzKrHESllkbezqCMstPmQA==",
+            "requires": {
+                "recoil": "*"
             }
         },
         "@types/resolve": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
         "@types/node": "^16.18.3",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.8",
+        "@types/recoil": "^0.0.9",
         "axios": "^1.1.3",
         "concurrently": "^7.5.0",
         "react": "^18.2.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import { Route, Routes } from "react-router-dom";
 import axios, { AxiosResponse } from "axios";
 import { TIME } from "#constants/time";
 import NewCourse from "#pages/NewCourse/NewCourse";
+import RecruitDetail from "#pages/RecruitDetail";
 
 function App() {
     const [userInfo, setUserInfo] = useRecoilState(userState);
@@ -51,6 +52,9 @@ function App() {
             <Route path="login" element={<Login />} />
             <Route path="course">
                 <Route path="new" element={<NewCourse />} />
+            </Route>
+            <Route path="recruit">
+                <Route path="detail" element={<RecruitDetail />} />
             </Route>
         </Routes>
     );

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -12,11 +12,19 @@ const MainPage = () => {
     const handleSignUpClick = () => {
         navigate("/signup");
     };
+    const handleCourseNewClick = () => {
+        navigate("/course/new");
+    };
+    const handleRecruitDetailClick = () => {
+        navigate("/recruit/detail");
+    };
 
     return (
         <>
             <button onClick={handleLoginClick}>로그인</button>
             <button onClick={handleSignUpClick}>회원가입 </button>
+            <button onClick={handleCourseNewClick}>코스등록 </button>
+            <button onClick={handleRecruitDetailClick}>코스상세 </button>
         </>
     );
 };

--- a/client/src/pages/RecruitDetail.styles.ts
+++ b/client/src/pages/RecruitDetail.styles.ts
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import { flexColumn } from "styles/flex";
+import { COLOR } from "styles/color";
+
+export const Title = styled.div`
+    box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.25);
+    font-size: 2rem;
+    font-weight: bold;
+    padding: 16px 10px 0px 10px;
+`;
+
+export const Content = styled.div`
+    ${flexColumn};
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 380px;
+    padding: 15px 19px;
+    div {
+        margin-bottom: 10px;
+        width: 100%;
+        color: ${COLOR.DARK_GRAY};
+        display: flex;
+        justify-content: space-between;
+        p {
+            font-weight: 500;
+            color: ${COLOR.BLACK};
+        }
+    }
+`;

--- a/client/src/pages/RecruitDetail.tsx
+++ b/client/src/pages/RecruitDetail.tsx
@@ -1,0 +1,45 @@
+import Header from "#components/Header/Header";
+import Button from "#components/Button/Button";
+import useMap from "#hooks/useMap";
+import { Content, Title } from "./RecruitDetail.styles";
+
+const RecruitDetail = () => {
+    const { renderMap } = useMap({
+        height: `${window.innerHeight - 500}px`,
+        center: { lat: 33.450701, lng: 126.570667 },
+    });
+    return (
+        <>
+            <Header loggedIn={true} text="모집 상세"></Header>
+            {renderMap()}
+            <Title>달려~달려~</Title>
+            <Content>
+                <div>
+                    <span>출발점</span>
+                    <p>잠실동 33-3</p>
+                </div>
+                <div>
+                    <span>페이스</span>
+                    <p>3'30"/km</p>
+                </div>
+                <div>
+                    <span>집합 일시</span>
+                    <p>2022년 11월 11일 오후 07시</p>
+                </div>
+                <div>
+                    <span>게시자</span>
+                    <p>gchoi96</p>
+                </div>
+                <div>
+                    <span>참가 현황</span>
+                    <p>1 / 5</p>
+                </div>
+                <Button width="fit" onClick={() => alert("참여 API 날림~")}>
+                    참여하기
+                </Button>
+            </Content>
+        </>
+    );
+};
+
+export default RecruitDetail;


### PR DESCRIPTION
## Feature

- 배경
모집 게시글 상세 페이지를 퍼블리싱한다.
- 목적
모집게시글의 상세내용을 보여주기 위함
## 과정
- 건님이 만들어주신 공통 컴포넌트들을 열심히 활용해본다.
## 결과 (스크린샷 등)
<img width="328" alt="스크린샷 2022-11-21 오후 6 12 20" src="https://user-images.githubusercontent.com/97938489/203011195-9f7b3ccd-c14d-45e8-8e7a-1275cce70710.png">

## 관련 issue 번호 (링크)
#53 
## 테스트 방법
http://localhost:3000/recruit/detail
## Commit
- 임시적으로 main페이지에 페이지 이동 가능한 버튼을 만들어놨습니다.
<img width="403" alt="스크린샷 2022-11-21 오후 6 12 43" src="https://user-images.githubusercontent.com/97938489/203011716-c982b85a-7272-46de-889c-12f65b81edba.png">

