### PR TITLE
feat: 코스상세 페이지 퍼블리싱

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import axios, { AxiosResponse } from "axios";
 import { TIME } from "#constants/time";
 import NewCourse from "#pages/NewCourse/NewCourse";
 import RecruitDetail from "#pages/RecruitDetail";
+import CourseDetail from "#pages/CourseDetail";
 
 function App() {
     const [userInfo, setUserInfo] = useRecoilState(userState);
@@ -52,6 +53,7 @@ function App() {
             <Route path="login" element={<Login />} />
             <Route path="course">
                 <Route path="new" element={<NewCourse />} />
+                <Route path="detail" element={<CourseDetail />} />
             </Route>
             <Route path="recruit">
                 <Route path="detail" element={<RecruitDetail />} />

--- a/client/src/pages/CourseDetail.styles.ts
+++ b/client/src/pages/CourseDetail.styles.ts
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import { COLOR } from "styles/color";
+import { flexColumn } from "styles/flex";
+
+export const Title = styled.div`
+    box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.25);
+    font-size: 2rem;
+    font-weight: bold;
+    padding: 20px 10px;
+`;
+
+export const Content = styled.div`
+    ${flexColumn};
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 210px;
+    padding: 15px 20px;
+    div {
+        margin-bottom: 10px;
+        width: 100%;
+        color: ${COLOR.DARK_GRAY};
+        display: flex;
+        justify-content: space-between;
+        p {
+            font-weight: 500;
+            color: ${COLOR.BLACK};
+        }
+    }
+`;

--- a/client/src/pages/CourseDetail.tsx
+++ b/client/src/pages/CourseDetail.tsx
@@ -1,0 +1,65 @@
+import Header from "#components/Header/Header";
+import Button from "#components/Button/Button";
+import useMap from "#hooks/useMap";
+import styled from "styled-components";
+import { flexColumn } from "styles/flex";
+import { COLOR } from "styles/color";
+
+export const Title = styled.div`
+    box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.25);
+    font-size: 2rem;
+    font-weight: bold;
+    padding: 20px 10px;
+`;
+
+export const Content = styled.div`
+    ${flexColumn};
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 210px;
+    padding: 15px 20px;
+    div {
+        margin-bottom: 10px;
+        width: 100%;
+        color: ${COLOR.DARK_GRAY};
+        display: flex;
+        justify-content: space-between;
+        p {
+            font-weight: 500;
+            color: ${COLOR.BLACK};
+        }
+    }
+`;
+const CourseDetail = () => {
+    const { renderMap } = useMap({
+        height: `${window.innerHeight - 330}px`,
+        center: { lat: 33.450701, lng: 126.570667 },
+    });
+    return (
+        <>
+            <Header loggedIn={true} text="코스 상세"></Header>
+            {renderMap()}
+            <Title>황새울공원 한 바퀴 도는 코스입니다.</Title>
+            <Content>
+                <div>
+                    <span>출발점</span>
+                    <p>잠실동 33-3</p>
+                </div>
+                <div>
+                    <span>총 거리</span>
+                    <p>3.3km</p>
+                </div>
+                <div>
+                    <span>게시자</span>
+                    <p>gchoi96</p>
+                </div>
+                <Button width="fit" onClick={() => alert("코스 모집 모달 on~")}>
+                    이 코스로 모집하기
+                </Button>
+            </Content>
+        </>
+    );
+};
+
+export default CourseDetail;

--- a/client/src/pages/CourseDetail.tsx
+++ b/client/src/pages/CourseDetail.tsx
@@ -1,36 +1,8 @@
 import Header from "#components/Header/Header";
 import Button from "#components/Button/Button";
 import useMap from "#hooks/useMap";
-import styled from "styled-components";
-import { flexColumn } from "styles/flex";
-import { COLOR } from "styles/color";
+import { Content, Title } from "./CourseDetail.styles";
 
-export const Title = styled.div`
-    box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.25);
-    font-size: 2rem;
-    font-weight: bold;
-    padding: 20px 10px;
-`;
-
-export const Content = styled.div`
-    ${flexColumn};
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    height: 210px;
-    padding: 15px 20px;
-    div {
-        margin-bottom: 10px;
-        width: 100%;
-        color: ${COLOR.DARK_GRAY};
-        display: flex;
-        justify-content: space-between;
-        p {
-            font-weight: 500;
-            color: ${COLOR.BLACK};
-        }
-    }
-`;
 const CourseDetail = () => {
     const { renderMap } = useMap({
         height: `${window.innerHeight - 330}px`,

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -18,13 +18,17 @@ const MainPage = () => {
     const handleRecruitDetailClick = () => {
         navigate("/recruit/detail");
     };
+    const handleCourseDetailClick = () => {
+        navigate("/course/detail");
+    };
 
     return (
         <>
             <button onClick={handleLoginClick}>로그인</button>
             <button onClick={handleSignUpClick}>회원가입 </button>
             <button onClick={handleCourseNewClick}>코스등록 </button>
-            <button onClick={handleRecruitDetailClick}>코스상세 </button>
+            <button onClick={handleRecruitDetailClick}>모집상세 </button>
+            <button onClick={handleCourseDetailClick}>코스상세 </button>
         </>
     );
 };

--- a/client/src/pages/RecruitDetail.styles.ts
+++ b/client/src/pages/RecruitDetail.styles.ts
@@ -6,7 +6,7 @@ export const Title = styled.div`
     box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.25);
     font-size: 2rem;
     font-weight: bold;
-    padding: 16px 10px 0px 10px;
+    padding: 10px 20px;
 `;
 
 export const Content = styled.div`
@@ -14,7 +14,7 @@ export const Content = styled.div`
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    height: 380px;
+    height: 300px;
     padding: 15px 19px;
     div {
         margin-bottom: 10px;

--- a/client/src/pages/RecruitDetail.tsx
+++ b/client/src/pages/RecruitDetail.tsx
@@ -5,7 +5,7 @@ import { Content, Title } from "./RecruitDetail.styles";
 
 const RecruitDetail = () => {
     const { renderMap } = useMap({
-        height: `${window.innerHeight - 500}px`,
+        height: `${window.innerHeight - 400}px`,
         center: { lat: 33.450701, lng: 126.570667 },
     });
     return (


### PR DESCRIPTION
## Feature

- 배경
코스 상세 페이지 퍼블리싱을 한다.
- 목적
사용자에게 코스에 대한 상세 내용을 보여주기 위함 
## 과정
- 코스 상세 페이지를 퍼블리싱 한다.
## 결과 (스크린샷 등)
<img width="333" alt="스크린샷 2022-11-21 오후 10 25 55" src="https://user-images.githubusercontent.com/97938489/203068400-63e89baf-a7b5-4e50-8871-dbe87c353999.png">

## 관련 issue 번호 (링크)
#58 
## 테스트 방법
http://localhost:3000/course/detail
## Commit
