### PR TITLE
feat: FE 유저 참여하기 API + 로그인 오류 수정(silentLogin)

### DIFF
--- a/client/src/atoms/userState.tsx
+++ b/client/src/atoms/userState.tsx
@@ -3,6 +3,7 @@ import { atom } from "recoil";
 interface userState {
     accessToken?: string;
     userId?: string;
+    userIdx: number;
 }
 
 export const userState = atom<userState>({
@@ -10,5 +11,6 @@ export const userState = atom<userState>({
     default: {
         accessToken: "",
         userId: "",
+        userIdx: 0,
     },
 });

--- a/client/src/components/Card/CourseCard/CourseCard.stories.tsx
+++ b/client/src/components/Card/CourseCard/CourseCard.stories.tsx
@@ -31,6 +31,6 @@ _CourseCard.args = {
         pathLength: 3355,
         userId: "gchoi96",
         img: "https://kr.object.ncloudstorage.com/j199/img/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202022-11-20%20%EC%98%A4%ED%9B%84%204.01.56.png",
-        zipCode: "신림동",
+        hCode: "신림동",
     },
 };

--- a/client/src/components/Card/CourseCard/CourseCard.tsx
+++ b/client/src/components/Card/CourseCard/CourseCard.tsx
@@ -14,7 +14,7 @@ const CourseCard = ({ data }: CourseCardProps) => {
             <SummaryBody>
                 <div>
                     <img src={LOCATION_ICON} />
-                    <span>{data.zipCode}</span>
+                    <span>{data.hCode}</span>
                     <img src={RULER_ICON} />
                     <span>{`${(data.pathLength / 1000).toFixed(1)}km`}</span>
                 </div>

--- a/client/src/components/Card/RecruitCard/RecruitCard.stories.tsx
+++ b/client/src/components/Card/RecruitCard/RecruitCard.stories.tsx
@@ -33,7 +33,7 @@ _RecruitCard.args = {
             pathLength: 3355,
             userId: "gchoi96",
             img: "https://kr.object.ncloudstorage.com/j199/img/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202022-11-20%20%EC%98%A4%ED%9B%84%204.01.56.png",
-            zipCode: "신림동",
+            hCode: "신림동",
         },
         startTime: new Date(),
         maxPpl: 4,

--- a/client/src/components/Card/RecruitCard/RecruitCard.tsx
+++ b/client/src/components/Card/RecruitCard/RecruitCard.tsx
@@ -15,7 +15,7 @@ const RecruitCard = ({ data }: RecruitCardProps) => {
             <SummaryBody>
                 <div>
                     <img src={LOCATION_ICON} />
-                    <span>{data.course.zipCode}</span>
+                    <span>{data.course.hCode}</span>
                     <img src={RULER_ICON} />
                     <span>{`${(data.course.pathLength / 1000).toFixed(1)}km`}</span>
                     <img src={RUNNING_ICON} />

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,13 +8,13 @@ import { RecoilRoot } from "recoil";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 root.render(
-    <React.StrictMode>
-        <RecoilRoot>
-            <BrowserRouter>
-                <App />
-            </BrowserRouter>
-        </RecoilRoot>
-    </React.StrictMode>,
+    // <React.StrictMode>
+    <RecoilRoot>
+        <BrowserRouter>
+            <App />
+        </BrowserRouter>
+    </RecoilRoot>,
+    // </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/client/src/pages/Courses.tsx
+++ b/client/src/pages/Courses.tsx
@@ -23,7 +23,7 @@ const DummyCardData = {
     pathLength: 3355,
     userId: "gchoi96",
     img: "https://kr.object.ncloudstorage.com/j199/img/%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202022-11-20%20%EC%98%A4%ED%9B%84%204.01.56.png",
-    zipCode: "신림동",
+    hCode: "신림동",
 };
 
 const CourseList = styled.div`

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -21,11 +21,11 @@ const Login = () => {
     const navigate = useNavigate();
 
     const checkFormValidation = () => {
-        return userId || password;
+        return userId && password;
     };
 
     const onSubmitLogin = () => {
-        if (checkFormValidation()) return;
+        if (!checkFormValidation()) return;
         axios
             .post(
                 "http://localhost:4000/auth/login",
@@ -38,7 +38,11 @@ const Login = () => {
                 },
             )
             .then((res) => {
-                setUserInfo({ accessToken: res.data.data.accessToken, userId: res.data.data.userId });
+                setUserInfo({
+                    accessToken: res.data.data.accessToken,
+                    userId: res.data.data.userId,
+                    userIdx: res.data.data.userIdx,
+                });
                 res.status === 201 && navigate("/", { replace: true });
             })
             .catch(console.log);

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -19,10 +19,10 @@ const MainPage = () => {
         navigate("/course/new");
     };
     const handleRecruitDetailClick = () => {
-        navigate("/recruit/detail");
+        navigate("/recruit/1");
     };
     const handleCourseDetailClick = () => {
-        navigate("/course/detail");
+        navigate("/course/1");
     };
 
     return (

--- a/client/src/pages/RecruitDetail.tsx
+++ b/client/src/pages/RecruitDetail.tsx
@@ -2,12 +2,42 @@ import Header from "#components/Header/Header";
 import Button from "#components/Button/Button";
 import useMap from "#hooks/useMap";
 import { Content, Title } from "./RecruitDetail.styles";
+import axios from "axios";
+import { useParams } from "react-router-dom";
+import { userState } from "#atoms/userState";
+import { useRecoilValue } from "recoil";
 
 const RecruitDetail = () => {
+    const { id } = useParams();
+    const userInfo = useRecoilValue(userState);
     const { renderMap } = useMap({
         height: `${window.innerHeight - 400}px`,
         center: { lat: 33.450701, lng: 126.570667 },
     });
+    const onSubmitJoin = () => {
+        axios
+            .post(
+                "http://localhost:4000/recruit/join",
+                {
+                    recruitId: id,
+                    userId: userInfo.userIdx,
+                },
+                {
+                    withCredentials: true,
+                    headers: {
+                        Authorization: `Bearer ${userInfo.accessToken}`,
+                    },
+                },
+            )
+            .then((res) => {
+                if (res.data.statusCode == 201) {
+                    alert("참여 완료");
+                } else {
+                    alert(res.data.message);
+                }
+            })
+            .catch(console.log);
+    };
     return (
         <>
             <Header loggedIn={true} text="모집 상세"></Header>
@@ -34,7 +64,7 @@ const RecruitDetail = () => {
                     <span>참가 현황</span>
                     <p>1 / 5</p>
                 </div>
-                <Button width="fit" onClick={() => alert("참여 API 날림~")}>
+                <Button width="fit" onClick={onSubmitJoin}>
                     참여하기
                 </Button>
             </Content>

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -5,7 +5,7 @@ import Input from "#components/Input/Input";
 import Button from "#components/Button/Button";
 import axios from "axios";
 import useInput from "#hooks/useInput";
-import { confirmPasswordValidator, idValidator, passwordValidator, zipCodeValidator } from "#utils/valitationUtils";
+import { confirmPasswordValidator, idValidator, passwordValidator, hCodeValidator } from "#utils/valitationUtils";
 import { InputWrapper, LogoWrapper, OptionsWrapper } from "./SignUp.styles";
 import { PLACEHOLDER } from "#constants/placeholder";
 import usePaceInput from "#hooks/usePaceInput";
@@ -17,11 +17,11 @@ const SignUp = () => {
     const [confirmPassword, onChangeConfirmPassword, confirmPasswordError] = useInput(
         confirmPasswordValidator(String(password)),
     );
-    const [zipCode, onChangeZipCode, zipCodeError] = useInput(zipCodeValidator);
+    const [hCode, onChangeHCode, hCodeError] = useInput(hCodeValidator);
     const { pace, onChangeMinute, onChangeSecond } = usePaceInput();
     const navigate = useNavigate();
 
-    const checkFormValidation = () => confirmPassword && password && userId && zipCode;
+    const checkFormValidation = () => confirmPassword && password && userId && hCode;
 
     const onSubmitSignUp = () => {
         if (!checkFormValidation()) return;
@@ -30,7 +30,7 @@ const SignUp = () => {
                 userId,
                 password,
                 pace: pace.minute * 60 + pace.second,
-                zipCode,
+                hCode,
             })
             .then((res) => res.status === 201 && navigate("/", { replace: true }))
             .catch(console.log);
@@ -52,8 +52,8 @@ const SignUp = () => {
                 ></Input>
                 <span>{confirmPasswordError}</span>
                 <PaceInput onChangeMinute={onChangeMinute} onChangeSecond={onChangeSecond}></PaceInput>
-                <Input placeholder={PLACEHOLDER.ZIP_CODE} type="number" onChange={onChangeZipCode}></Input>
-                <span>{zipCodeError}</span>
+                <Input placeholder={PLACEHOLDER.ZIP_CODE} type="number" onChange={onChangeHCode}></Input>
+                <span>{hCodeError}</span>
                 <Button width="fill" onClick={onSubmitSignUp}>
                     회원가입
                 </Button>

--- a/client/src/types/Course.ts
+++ b/client/src/types/Course.ts
@@ -5,7 +5,7 @@ export interface Course {
     courseId: number;
     path: LatLng[];
     pathLength: number;
-    zipCode: string;
+    hCode: string;
     userId: string;
     img: string;
 }

--- a/client/src/utils/valitationUtils.ts
+++ b/client/src/utils/valitationUtils.ts
@@ -12,6 +12,6 @@ export const confirmPasswordValidator = (password: string) => (confirmPassword: 
     return password !== confirmPassword || !confirmPassword ? "비밀번호가 일치하지 않습니다" : "";
 };
 
-export const zipCodeValidator = (zipCode: string) => {
-    return zipCode.length === 5 ? "" : "지역을 입력하세요";
+export const hCodeValidator = (hCode: string) => {
+    return hCode.length === 5 ? "" : "지역을 입력하세요";
 };


### PR DESCRIPTION
## Feature

- 배경
모집 상세 페이지에서 유저 참여하기 api를 구현한다.
- 목적
사용자가 모집 게시글을 보고 러닝에 참여하도록 하기 위함
## 과정
1. 유저 참여 API
'참여하기' 버튼 클릭 시, userInfo에 저장되어있는 유저의 idx와 recruit의 id로 유처 참여를 등록한다.
+  로그인 관련 오류 수정
- 새로고침 시, refresh토큰으로 userInfo 상태를 업데이트 해준다.
## 결과 (스크린샷 등)

## 관련 issue 번호 (링크)
#59 
## 테스트 방법
로그인 -> `http://localhost:3000/recruit/:id` -> 참여하기 버튼 클릭
## Commit
