### PR TITLE
feat: BE 모집 상세 페이지 API

### DIFF
--- a/server/src/recruit/recruit.controller.ts
+++ b/server/src/recruit/recruit.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, UseGuards, Query } from "@nestjs/common";
+import { Body, Controller, Get, Post, UseGuards, Query, Param } from "@nestjs/common";
 import { AccessGuard } from "src/common/guard/access.guard";
 import { CreateRecruitDto } from "./dto/create-recruit.dto";
 import { JoinRecruitDto } from "./dto/join-recruit.dto";
@@ -61,6 +61,16 @@ export class RecruitController {
         this.recruitService.join(userId, recruitId);
         return {
             statusCode: 201,
+        };
+    }
+
+    @Get(":id")
+    async getRecruitDetail(@Param("id") recruitId: number, @Body("userIdx") userIdx: number) {
+        const data = await this.recruitService.getRecruitDetail(recruitId);
+        return {
+            ...data,
+            isAuthor: data.authorId === userIdx,
+            isParticipating: await this.recruitService.isParticipating(recruitId, userIdx),
         };
     }
 }

--- a/server/src/recruit/recruit.repository.ts
+++ b/server/src/recruit/recruit.repository.ts
@@ -2,11 +2,35 @@ import { CustomRepository } from "src/common/typeorm/typeorm.decorator";
 import { Recruit } from "src/entities/recruit.entity";
 import { Repository } from "typeorm";
 import { RawRecruitData } from "src/common/type/raw-recruit-data";
+import { BadRequestException } from "@nestjs/common";
+import { UserRecruitRepository } from "src/user_recruit.repository";
 
 @CustomRepository(Recruit)
 export class RecruitRepository extends Repository<Recruit> {
     async createOne(recruitEntity: Recruit): Promise<Recruit> {
         return this.save(recruitEntity);
+    }
+    async findRecruitDetail(recruitId: number) {
+        await this.findOneById(recruitId);
+        return this.createQueryBuilder("recruit")
+            .innerJoinAndSelect("recruit.course", "course")
+            .leftJoinAndSelect("recruit.userRecruits", "user_recruit")
+            .innerJoinAndSelect("recruit.user", "user")
+            .select([
+                "recruit.title AS title",
+                "recruit.startTime AS startTime",
+                "recruit.name AS name",
+                "recruit.maxPpl AS maxPpl",
+                "recruit.pace AS pace",
+                "recruit.userId AS authorId",
+                "user.userId AS userId",
+                "COUNT(user_recruit.userId) AS currentPpl",
+                "course.path AS path",
+                "course.pathLength AS pathLength",
+                "user.userId AS userId",
+            ])
+            .where("recruit.id = :recruitId", { recruitId })
+            .getRawOne();
     }
 
     async findAll(page: number, pageSize: number): Promise<RawRecruitData[]> {
@@ -22,6 +46,7 @@ export class RecruitRepository extends Repository<Recruit> {
                 "recruit.createdAt AS createdAt",
                 "user.userId AS userId",
                 "COUNT(user_recruit.id) AS currentPpl",
+                "user_recruit.id",
                 "course.id",
                 "course.title",
                 "course.img",
@@ -36,11 +61,15 @@ export class RecruitRepository extends Repository<Recruit> {
             .getRawMany();
     }
 
-    async findOneById(recruitId: number): Promise<Recruit> {
-        return await this.findOneBy({ id: recruitId });
+    async findOneById(id: number): Promise<Recruit> {
+        const data = await this.findOneBy({ id });
+        if (!data) {
+            throw new BadRequestException();
+        }
+        return data;
     }
 
-    async getMaxPpl(recruitId: number) {
-        return (await this.findOneById(recruitId)).maxPpl;
+    async getMaxPpl(id: number) {
+        return (await this.findOneById(id)).maxPpl;
     }
 }

--- a/server/src/recruit/recruit.service.ts
+++ b/server/src/recruit/recruit.service.ts
@@ -21,6 +21,9 @@ export class RecruitService {
         return this.recruitRepository.createOne(recruitEntity);
     }
 
+    async getRecruitDetail(recruitId: number) {
+        return await this.recruitRepository.findRecruitDetail(recruitId);
+    }
     async getRecruitList(page: number, pageSize: number) {
         const recruitList = await this.recruitRepository.findAll(page, pageSize);
         return recruitList.map(
@@ -77,7 +80,7 @@ export class RecruitService {
     }
 
     async isVacancy(recruitId: number): Promise<boolean> {
-        const currentPpl = await this.userRecruitRepository.countCurrentPpl(recruitId);
+        const currentPpl = await this.getCurrentPpl(recruitId);
         const maxPpl = await this.recruitRepository.getMaxPpl(recruitId);
         if (currentPpl < maxPpl) {
             return true;
@@ -85,10 +88,15 @@ export class RecruitService {
         return false;
     }
 
+    async getCurrentPpl(recruitId: number) {
+        return await this.userRecruitRepository.countCurrentPpl(recruitId);
+    }
+
     async isAuthorOfRecruit(recruitId: number, userId: number) {
         const recruitEntity = await this.recruitRepository.findOneById(recruitId);
         return recruitEntity.userId === userId;
     }
+
     join(userId: number, recruitId: number) {
         this.userRecruitRepository.createUserRecruit(userId, recruitId);
     }


### PR DESCRIPTION
## Feature

- 배경
BE에서 모집 상세페이지에 해당하는 데이터를 응답해준다
- 목적
사용자에게 모집 상세 내용을 보여주기 위함
## 과정
- recruit id 에 해당하는 param을 통해 해당 모집 글의 data를 응답해준다.
## 결과 (스크린샷 등)
![스크린샷 2022-11-24 오후 10 39 53](https://user-images.githubusercontent.com/97938489/203798868-3019030f-2f9e-4342-8791-a4204b2b8266.png)

## 관련 issue 번호 (링크)
#82
## 테스트 방법
`GET localhost:4000/recruit/4`
```json
{
    "userIdx": 2
}
```
## Commit
