### PR TITLE
feat: 모집 상세 api 연동

### DIFF
--- a/client/src/hooks/http/useHttpPost.ts
+++ b/client/src/hooks/http/useHttpPost.ts
@@ -9,6 +9,10 @@ const useGet = () => {
             .post(url, data)
             .then((res) => {
                 setIsLoading(false);
+                const data = res.data;
+                if (data.statusCode >= 400) {
+                    throw new Error(data.message);
+                }
                 return res.data;
             })
             .catch((error) => {

--- a/client/src/pages/RecruitDetail.tsx
+++ b/client/src/pages/RecruitDetail.tsx
@@ -1,25 +1,42 @@
 import Header from "#components/Header/Header";
 import Button from "#components/Button/Button";
-import useMap from "#hooks/useMap";
 import { Content, Title } from "./RecruitDetail.styles";
 import { useParams } from "react-router-dom";
 import { userState } from "#atoms/userState";
 import { useRecoilValue } from "recoil";
 import useHttpPost from "#hooks/http/useHttpPost";
+import useHttpGet from "#hooks/http/useHttpGet";
+import { useEffect, useState, useCallback } from "react";
+import ViewMap from "#components/Map/ViewMap/ViewMap";
 
 const RecruitDetail = () => {
     const { id } = useParams();
     const userInfo = useRecoilValue(userState);
     const { post } = useHttpPost();
-    const { renderMap } = useMap({
-        height: `${window.innerHeight - 400}px`,
-        center: { lat: 33.450701, lng: 126.570667 },
-    });
+    const { get } = useHttpGet();
+    const [title, setTitle] = useState("제목");
+    const [startPoint, setStartPoint] = useState("출발점");
+    const [pace, setPace] = useState("페이스ㄴ");
+    const [startTime, setStartTime] = useState("집합 일시");
+    const [author, setAuthor] = useState("게시자");
+    const [maxPpl, setMaxPpl] = useState("최대 인원");
+    const [currentPpl, setCurrentPpl] = useState("현재 인원");
 
+    const getPaceFormat = (sec: number): string => {
+        return `${parseInt(String(sec / 60))}'${sec % 60}"`;
+    };
+
+    const getTimeFormat = (timeZone: string): string => {
+        const date = timeZone.split("T")[0].split("-");
+        const time = timeZone.split("T")[1].split(":");
+        return `${date[0]}년 ${date[1]}월 ${date[2]}일 ${Number(time[0]) >= 12 ? "오후" : "오전"} ${time[0]}시 ${
+            time[1]
+        }분`;
+    };
     const onSubmitJoin = async () => {
         try {
             await post("/recruit/join", {
-                recruit: id,
+                recruitId: id,
                 userId: userInfo.userIdx,
             });
             alert("참여 완료");
@@ -27,31 +44,53 @@ const RecruitDetail = () => {
             alert(error.message);
         }
     };
+
+    const getRecruitDetail = useCallback(async () => {
+        try {
+            const response = await get(`/recruit/${id}`);
+            setTitle(response.title);
+            setStartPoint(response.name);
+            setPace(getPaceFormat(response.pace));
+            setStartTime(getTimeFormat(response.startTime));
+            setAuthor(response.userId);
+            setMaxPpl(response.maxPpl);
+            setCurrentPpl(response.currentPpl);
+        } catch {}
+    }, []);
+
+    useEffect(() => {
+        if (!userInfo.accessToken) {
+            return;
+        }
+        getRecruitDetail();
+    }, [userInfo]);
     return (
         <>
             <Header loggedIn={true} text="모집 상세"></Header>
-            {renderMap()}
-            <Title>달려~달려~</Title>
+            <ViewMap />
+            <Title>{title}</Title>
             <Content>
                 <div>
                     <span>출발점</span>
-                    <p>잠실동 33-3</p>
+                    <p>{startPoint}</p>
                 </div>
                 <div>
                     <span>페이스</span>
-                    <p>3'30"/km</p>
+                    <p>{pace}/km</p>
                 </div>
                 <div>
                     <span>집합 일시</span>
-                    <p>2022년 11월 11일 오후 07시</p>
+                    <p>{startTime}</p>
                 </div>
                 <div>
                     <span>게시자</span>
-                    <p>gchoi96</p>
+                    <p>{author}</p>
                 </div>
                 <div>
                     <span>참가 현황</span>
-                    <p>1 / 5</p>
+                    <p>
+                        {currentPpl} / {maxPpl}
+                    </p>
                 </div>
                 <Button width="fit" onClick={onSubmitJoin}>
                     참여하기

--- a/server/src/recruit/recruit.controller.ts
+++ b/server/src/recruit/recruit.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Get, Post, UseGuards, Query, Param } from "@nestjs/common";
+import {
+    Body,
+    Controller,
+    Get,
+    Post,
+    UseGuards,
+    Query,
+    Param,
+    Req,
+    HttpException,
+    BadRequestException,
+} from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
 import { AccessGuard } from "src/common/guard/access.guard";
 import { CreateRecruitDto } from "./dto/create-recruit.dto";
 import { JoinRecruitDto } from "./dto/join-recruit.dto";
@@ -6,7 +18,7 @@ import { RecruitService } from "./recruit.service";
 
 @Controller("recruit")
 export class RecruitController {
-    constructor(private readonly recruitService: RecruitService) {}
+    constructor(private readonly recruitService: RecruitService, private jwtService: JwtService) {}
 
     @Get()
     async getRecruits(@Query("page") page: number, @Query("pageSize") pageSize?: number) {
@@ -32,29 +44,35 @@ export class RecruitController {
     // @UseGuards(AccessGuard)
     @Post("join")
     async register(@Body() joinRecruitDto: JoinRecruitDto) {
+        console.log(joinRecruitDto);
         const recruitId = joinRecruitDto.getRecruitId();
         const userId = joinRecruitDto.getUserId();
         if (!(await this.recruitService.isExistRecruit(recruitId))) {
             return {
                 statusCode: 409,
+                error: "conflict",
                 message: "Does not exist or has been deleted",
             };
         }
         if (await this.recruitService.isAuthorOfRecruit(recruitId, userId)) {
             return {
                 statusCode: 423,
+                error: "Locked",
                 message: "Cannot participate in your own recruitment",
             };
         }
+
         if (await this.recruitService.isParticipating(recruitId, userId)) {
             return {
                 statusCode: 423,
+                error: "Locked",
                 message: "You have already participated.",
             };
         }
         if (!(await this.recruitService.isVacancy(recruitId))) {
             return {
                 statusCode: 423,
+                error: "Locked",
                 message: "Maximum cap reached",
             };
         }
@@ -65,8 +83,12 @@ export class RecruitController {
     }
 
     @Get(":id")
-    async getRecruitDetail(@Param("id") recruitId: number, @Body("userIdx") userIdx: number) {
+    async getRecruitDetail(@Param("id") recruitId: number, @Req() request: Request) {
+        console.log("a");
+        const jwtString = request.headers["authorization"].split("Bearer")[1].trim();
+        const { userIdx } = this.jwtService.verify(jwtString, { secret: process.env.ACCESS_SECRET });
         const data = await this.recruitService.getRecruitDetail(recruitId);
+        // return 1;
         return {
             ...data,
             isAuthor: data.authorId === userIdx,

--- a/server/src/recruit/recruit.service.ts
+++ b/server/src/recruit/recruit.service.ts
@@ -76,7 +76,7 @@ export class RecruitService {
     }
 
     async isParticipating(recruitId: number, userId: number): Promise<boolean> {
-        return this.userRecruitRepository.isParticipate(recruitId, userId);
+        return await this.userRecruitRepository.isParticipating(recruitId, userId);
     }
 
     async isVacancy(recruitId: number): Promise<boolean> {

--- a/server/src/user_recruit.repository.ts
+++ b/server/src/user_recruit.repository.ts
@@ -4,12 +4,12 @@ import { UserRecruit } from "./entities/user_recruit.entity";
 
 @CustomRepository(UserRecruit)
 export class UserRecruitRepository extends Repository<UserRecruit> {
-    public async isParticipate(recruitId: number, userId: number): Promise<boolean> {
-        const participants = await this.createQueryBuilder("user_recruit")
+    public async isParticipating(recruitId: number, userId: number): Promise<boolean> {
+        const userRecruit = await this.createQueryBuilder("user_recruit")
             .where("user_recruit.recruitId = :recruitId", { recruitId })
             .andWhere("user_recruit.userId = :userId", { userId })
             .getOne();
-        if (participants) {
+        if (userRecruit) {
             return true;
         }
         return false;


### PR DESCRIPTION
## Feature

- 배경
서버에서 응답해준 모집 상세페이지 data를 화면에 렌더링한다.
- 목적
사용자에게 모집에 대한 정보를 보여주기 위함
## 과정
훅을 사용하여 data를 렌더링 해준다

## 결과 (스크린샷 등)
<img width="333" alt="스크린샷 2022-11-25 오전 2 30 05" src="https://user-images.githubusercontent.com/97938489/203840553-252b9b65-229e-4e7e-a8db-5909258c286a.png">

## 관련 issue 번호 (링크)
#82 

## 테스트 방법
`GET http://localhost:3000/recruit/:id`
## Commit
