### PR TITLE
feat: 모집 상세 페이지 지도위에 코스 나타내기 성공

### DIFF
--- a/client/src/hooks/useShowMap.tsx
+++ b/client/src/hooks/useShowMap.tsx
@@ -1,0 +1,57 @@
+import ZoomControl from "#components/MapControl/ZoomControl/ZoomControl";
+import { LatLng } from "#types/LatLng";
+import { MapProps } from "#types/MapProps";
+import { useCallback, useEffect, useRef, useState } from "react";
+import useZoomControl from "./useZoomControl";
+
+const useShowMap = ({ height = "100vh", center, level = 1, runningPath }: MapProps) => {
+    const container = useRef<HTMLDivElement>(null);
+    const map = useRef<kakao.maps.Map>();
+    const polyLineRef = useRef<kakao.maps.Polyline>();
+    const [path, setPath] = useState<kakao.maps.LatLng[]>([]);
+    const { zoomIn, zoomOut } = useZoomControl(map);
+
+    useEffect(() => {
+        if (!container.current) return;
+        map.current = new kakao.maps.Map(container.current, {
+            center: new kakao.maps.LatLng(center.lat, center.lng),
+            level,
+        });
+        polyLineRef.current = new kakao.maps.Polyline({
+            map: map.current,
+            path,
+        });
+        DrawPath(runningPath);
+    }, [runningPath]);
+    const getLaMaByLatLng = (point: LatLng): kakao.maps.LatLng => {
+        return new kakao.maps.LatLng(point.lat, point.lng);
+    };
+    const DrawPath = useCallback(
+        async (path: { lat: number; lng: number }[] | undefined) => {
+            if (!path) {
+                return;
+            }
+            if (!polyLineRef.current) return;
+            for (const point of path) {
+                const position = getLaMaByLatLng(point);
+                const newPath = [...polyLineRef.current.getPath(), position];
+                setPath(newPath);
+                polyLineRef.current.setPath(newPath);
+            }
+        },
+        [polyLineRef],
+    );
+
+    return {
+        map: map.current,
+        path,
+        renderMap: () => (
+            <div style={{ position: "relative" }}>
+                <div ref={container} style={{ width: "100vw", height }} />
+                <ZoomControl onClickZoomIn={zoomIn} onClickZoomOut={zoomOut} />
+            </div>
+        ),
+    };
+};
+
+export default useShowMap;

--- a/client/src/hooks/useWriteMap.tsx
+++ b/client/src/hooks/useWriteMap.tsx
@@ -46,6 +46,7 @@ const useWriteMap = ({ height = "100vh", center, level = 1 }: MapProps) => {
         async (mouseEvent: kakao.maps.event.MouseEvent) => {
             if (!polyLineRef.current) return;
             const position = mouseEvent.latLng;
+            console.log(mouseEvent.latLng);
             const isRoad = await checkIsRoad(position);
             if (isRoad) {
                 const newPath = [...polyLineRef.current.getPath(), position];

--- a/client/src/types/MapProps.ts
+++ b/client/src/types/MapProps.ts
@@ -11,4 +11,5 @@ export interface MapProps {
      * 숫자가 작을수록 zoom-in
      */
     level?: number;
+    runningPath?: { lat: number; lng: number }[];
 }


### PR DESCRIPTION
## Feature

- 배경
모집 상세 페이지 지도에 러닝 코스를 나타낸다.
- 목적
사용자에게 대략적인 러닝 코스를 제공하기 위함
## 과정
- 서버에서 응답해준 path를 통해 위도경도를 찍어가며 지도 위에 나타낸다.
## 결과 (스크린샷 등)
<img width="321" alt="스크린샷 2022-11-25 오전 6 31 46" src="https://user-images.githubusercontent.com/97938489/203865548-89cc3466-23cf-4ca9-9201-1c6215431eba.png">

## 관련 issue 번호 (링크)
#82 
## 테스트 방법
`GET http://localhost:3000/recruit/1`
## Commit
