### PR TITLE
refactor: time->hour로 파라미터 변경 작업 및 응답에서 course.userId가 누락되어 있던 문제 수정

### DIFF
--- a/server/src/common/type/raw-recruit-data.ts
+++ b/server/src/common/type/raw-recruit-data.ts
@@ -6,6 +6,7 @@ export interface RawRecruitData {
     course_pathLength: number;
     course_name: string;
     course_createdAt: Date;
+    course_userId: string;
     id: number;
     title: string;
     startTime: Date;

--- a/server/src/common/utils/plainToGetRecruitDto.ts
+++ b/server/src/common/utils/plainToGetRecruitDto.ts
@@ -17,6 +17,7 @@ export const plainToGetRecruitDto = (plainRecruitData: RawRecruitData) => {
         course_pathLength,
         course_name,
         course_createdAt,
+        course_userId,
     } = plainRecruitData;
 
     return {
@@ -34,6 +35,7 @@ export const plainToGetRecruitDto = (plainRecruitData: RawRecruitData) => {
             img: course_img,
             path: course_path,
             pathLength: course_pathLength,
+            userId: course_userId,
             hDong: {
                 name: course_name,
             },

--- a/server/src/recruit/dto/get-recruit.dto.ts
+++ b/server/src/recruit/dto/get-recruit.dto.ts
@@ -8,7 +8,7 @@ export class GetRecruitDto {
     @IsOptional()
     @Type(() => Number)
     @IsNumber()
-    private time?: number;
+    private hour?: number;
 
     @IsOptional()
     @Type(() => Number)
@@ -66,8 +66,8 @@ export class GetRecruitDto {
         return this.query;
     }
 
-    getTime(): number | undefined {
-        return this.time;
+    getHour(): number | undefined {
+        return this.hour;
     }
 
     getDist(): number | undefined {

--- a/server/src/recruit/recruit.controller.ts
+++ b/server/src/recruit/recruit.controller.ts
@@ -1,21 +1,10 @@
-import {
-    Body,
-    Controller,
-    Get,
-    Post,
-    UseGuards,
-    Query,
-    Param,
-    Req,
-    HttpException,
-    BadRequestException,
-} from "@nestjs/common";
+import { Body, Controller, Get, Post, Query, Param, Req } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
-import { AccessGuard } from "src/common/guard/access.guard";
 import { CreateRecruitDto } from "./dto/create-recruit.dto";
 import { GetRecruitDto } from "./dto/get-recruit.dto";
 import { JoinRecruitDto } from "./dto/join-recruit.dto";
 import { RecruitService } from "./recruit.service";
+import { Request } from "express";
 
 @Controller("recruit")
 export class RecruitController {
@@ -45,7 +34,6 @@ export class RecruitController {
     // @UseGuards(AccessGuard)
     @Post("join")
     async register(@Body() joinRecruitDto: JoinRecruitDto) {
-        console.log(joinRecruitDto);
         const recruitId = joinRecruitDto.getRecruitId();
         const userId = joinRecruitDto.getUserId();
         if (!(await this.recruitService.isExistRecruit(recruitId))) {
@@ -85,11 +73,9 @@ export class RecruitController {
 
     @Get(":id")
     async getRecruitDetail(@Param("id") recruitId: number, @Req() request: Request) {
-        console.log("a");
         const jwtString = request.headers["authorization"].split("Bearer")[1].trim();
         const { userIdx } = this.jwtService.verify(jwtString, { secret: process.env.ACCESS_SECRET });
         const data = await this.recruitService.getRecruitDetail(recruitId);
-        // return 1;
         return {
             ...data,
             isAuthor: data.authorId === userIdx,

--- a/server/src/recruit/recruit.repository.ts
+++ b/server/src/recruit/recruit.repository.ts
@@ -9,6 +9,7 @@ export class RecruitRepository extends Repository<Recruit> {
     async createOne(recruitEntity: Recruit): Promise<Recruit> {
         return this.save(recruitEntity);
     }
+
     async findRecruitDetail(recruitId: number) {
         await this.findOneById(recruitId);
         return this.createQueryBuilder("recruit")
@@ -17,7 +18,7 @@ export class RecruitRepository extends Repository<Recruit> {
             .innerJoinAndSelect("recruit.user", "user")
             .select([
                 "recruit.title AS title",
-                "recruit.startTime AS startTime",
+                "STR_TO_DATE(recruit.startTime) AS startTime",
                 "recruit.name AS name",
                 "recruit.maxPpl AS maxPpl",
                 "recruit.pace AS pace",
@@ -38,16 +39,17 @@ export class RecruitRepository extends Repository<Recruit> {
         query?: string | undefined,
         title?: boolean | undefined,
         author?: boolean | undefined,
-        time?: number | undefined,
+        hour?: number | undefined,
         minLen?: number | undefined,
         maxLen?: number | undefined,
     ): Promise<RawRecruitData[]> {
         return this.createQueryBuilder("recruit")
             .innerJoinAndSelect("recruit.course", "course")
+            .innerJoinAndSelect("course.user", "u")
             .leftJoinAndSelect("recruit.userRecruits", "user_recruit")
             .innerJoinAndSelect("recruit.user", "user")
             .where("recruit.startTime > NOW()")
-            .andWhere(time ? `recruit.startTime < DATE_ADD(NOW(), INTERVAL :time HOUR)` : "1=1", { time })
+            .andWhere(hour ? `recruit.startTime < DATE_ADD(NOW(), INTERVAL :hour HOUR)` : "1=1", { hour })
             .andWhere(maxLen && minLen >= 0 ? `course.pathLength >= :minLen and course.pathLength < :maxLen` : "1=1", {
                 minLen,
                 maxLen,
@@ -79,6 +81,7 @@ export class RecruitRepository extends Repository<Recruit> {
                 "course.hCode",
                 "course.name",
                 "course.createdAt",
+                "u.userId AS course_userId",
             ])
             .groupBy("recruit.id")
             .offset((page - 1) * pageSize)

--- a/server/src/recruit/recruit.service.ts
+++ b/server/src/recruit/recruit.service.ts
@@ -37,7 +37,7 @@ export class RecruitService {
             queryParams.getQuery(),
             queryParams.getTitle(),
             queryParams.getAuthor(),
-            queryParams.getTime(),
+            queryParams.getHour(),
             queryParams.getMinLength(),
             queryParams.getMaxLength(),
         );


### PR DESCRIPTION
## Feature

- 배경
   - time 대신 hour로 쿼리스트링을 변경하기로 결정 (의미를 좀 더 명확하게 전달 위함)
   - 기존 응답에서 course 부분에서 userId가 누락되어 있음
- 목적
   - time 대신 hour로 변경 (예시: GET /recruit?query=randomTitle&hour=3)
   - userId 누락 문제 수정
## 과정
   - 해당 레이어 수정
   - 쿼리문 일부 수정
## 결과 (스크린샷 등)
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/61878436/204082668-28059416-aa1f-4b39-aa6d-57274f556efe.png">

## 관련 issue 번호 (링크)
#110 
## 테스트 방법
Postman
## Comment
Recruit page에서도 쿼리파라미터로 time 대신 hour로 변경해서 보내게끔 수정 필요할 것 같습니다.
