### PR TITLE
feat: 클라이언트 요청을 가로채서 userId 필드 추가하게끔 인터셉터 적용

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -17,6 +17,9 @@ import type { ClientOpts } from "redis";
 import { RecruitModule } from "./recruit/recruit.module";
 import { CourseModule } from "./course/course.module";
 import { CustomJwtModule } from "./common/modules/custom-jwt/custom-jwt.module";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { HttpRequestBodyInterceptor } from "./common/interceptors/http-request/http-request-body.interceptor";
+import { HttpRequestBodyModule } from "./common/interceptors/http-request/http-request-body.module";
 
 @Module({
     imports: [
@@ -44,6 +47,7 @@ import { CustomJwtModule } from "./common/modules/custom-jwt/custom-jwt.module";
         ServeStaticModule.forRoot({
             rootPath: join(__dirname, "..", "..", "client", "build"),
         }),
+        HttpRequestBodyModule,
         CustomJwtModule,
         UserModule,
         AuthModule,
@@ -51,6 +55,12 @@ import { CustomJwtModule } from "./common/modules/custom-jwt/custom-jwt.module";
         CourseModule,
     ],
     controllers: [AppController],
-    providers: [AppService],
+    providers: [
+        AppService,
+        {
+            provide: APP_INTERCEPTOR,
+            useClass: HttpRequestBodyInterceptor,
+        },
+    ],
 })
 export class AppModule {}

--- a/server/src/common/interceptors/http-request/http-request-body.interceptor.ts
+++ b/server/src/common/interceptors/http-request/http-request-body.interceptor.ts
@@ -1,0 +1,22 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { CustomJwtService } from "src/common/modules/custom-jwt/custom-jwt.service";
+
+@Injectable()
+export class HttpRequestBodyInterceptor implements NestInterceptor {
+    constructor(private jwtService: CustomJwtService) {}
+
+    intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+        const request = context.switchToHttp().getRequest();
+        const accessToken = request.headers["authorization"];
+
+        if (accessToken) {
+            try {
+                const { userIdx } = this.jwtService.verifyAccessToken(accessToken);
+                request.body.userId = userIdx;
+            } catch (err) {}
+        }
+
+        return next.handle();
+    }
+}

--- a/server/src/common/interceptors/http-request/http-request-body.module.ts
+++ b/server/src/common/interceptors/http-request/http-request-body.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { CustomJwtModule } from "src/common/modules/custom-jwt/custom-jwt.module";
+import { HttpRequestBodyInterceptor } from "./http-request-body.interceptor";
+
+@Module({
+    imports: [CustomJwtModule],
+    providers: [{ provide: APP_INTERCEPTOR, useClass: HttpRequestBodyInterceptor }],
+})
+export class HttpRequestBodyModule {}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -13,7 +13,11 @@ async function bootstrap() {
         .addTag("app")
         .build();
     const document = SwaggerModule.createDocument(app, options);
-    app.enableCors({ origin: true, methods: "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS", credentials: true });
+    app.enableCors({
+        origin: "http://localhost:3000",
+        methods: "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS",
+        credentials: true,
+    });
     app.use(cookieParser());
     app.useGlobalPipes(
         new ValidationPipe({

--- a/server/src/recruit/recruit.module.ts
+++ b/server/src/recruit/recruit.module.ts
@@ -2,8 +2,6 @@ import { Module } from "@nestjs/common";
 import { RecruitService } from "./recruit.service";
 import { RecruitController } from "./recruit.controller";
 import { TypeOrmCustomModule } from "src/common/typeorm/typeorm.module";
-import { AuthService } from "src/auth/auth.service";
-import { AuthRepository } from "src/common/repositories/auth.repository";
 import { UserRepository } from "src/common/repositories/user.repository";
 import { UserRecruitRepository } from "src/common/repositories/user_recruit.repository";
 import { RecruitRepository } from "../common/repositories/recruit.repository";


### PR DESCRIPTION
## Feature

- 배경
   - 요청을 가로채서 userId 필드를 추가해주는 인터셉터 구현
- 목적
   - 헤더에 액세스 토큰이 유효하다면, 요청 body에 userId 필드를 추가
   - 인터셉터 적용시 컨트롤러나 서비스 로직 수정없이, 파이프 단계에서 dto 객체로 자동 변환

## 과정
- [X] 인터셉터 구현
- [X] 글로벌 인터셉터로 적용
## 결과 (스크린샷 등)
![image](https://user-images.githubusercontent.com/61878436/204289393-ce5903c8-cc8b-45a5-9fce-a7182e36a94b.png)
![image](https://user-images.githubusercontent.com/61878436/204289565-5b9eb416-5ffd-4c53-bb3f-761ad2200baa.png)

- userId를 요청에 실어 보내지 않아도 헤더에서 확인 후 필드에 추가해주는 예시
## 관련 issue 번호 (링크)
#139
## 테스트 방법
Postman
## Comment
Authorization 헤더에 액세스 토큰이 존재할때만 필드에 추가됩니다.