### PR TITLE
feat: 코스 상세 페이지 지도에 코스 나타내기 + 줌 아웃

### DIFF
--- a/client/src/hooks/useShowMap.tsx
+++ b/client/src/hooks/useShowMap.tsx
@@ -9,7 +9,7 @@ const useShowMap = ({ height = "50vh", center, level = 1, runningPath }: MapProp
     const container = useRef<HTMLDivElement>(null);
     const map = useRef<kakao.maps.Map>();
     const polyLineRef = useRef<kakao.maps.Polyline>();
-    const [path, setPath] = useState<kakao.maps.LatLng[]>([]);
+    const [path] = useState<kakao.maps.LatLng[]>([]);
     const { zoomIn, zoomOut } = useZoomControl(map);
 
     useEffect(() => {
@@ -28,7 +28,6 @@ const useShowMap = ({ height = "50vh", center, level = 1, runningPath }: MapProp
         const sw = new kakao.maps.LatLng(pathBounds.minLat, pathBounds.minLng);
         const ne = new kakao.maps.LatLng(pathBounds.maxLat, pathBounds.maxLng);
         const mapBounds = new kakao.maps.LatLngBounds(sw, ne);
-        // const bounds = map.current.LatLngBounds();
         map.current.setBounds(mapBounds);
     }, [runningPath, map]);
 
@@ -37,17 +36,12 @@ const useShowMap = ({ height = "50vh", center, level = 1, runningPath }: MapProp
     };
 
     const DrawPath = useCallback(
-        async (path: { lat: number; lng: number }[] | undefined) => {
+        async (path: LatLng[] | undefined) => {
             if (!path) {
                 return;
             }
             if (!polyLineRef.current) return;
-            for (const point of path) {
-                const position = getLaMaByLatLng(point);
-                const newPath = [...polyLineRef.current.getPath(), position];
-                setPath(newPath);
-                polyLineRef.current.setPath(newPath);
-            }
+            polyLineRef.current.setPath(path.map((point) => getLaMaByLatLng(point)));
         },
         [polyLineRef],
     );

--- a/client/src/hooks/useShowMap.tsx
+++ b/client/src/hooks/useShowMap.tsx
@@ -1,10 +1,11 @@
 import ZoomControl from "#components/MapControl/ZoomControl/ZoomControl";
 import { LatLng } from "#types/LatLng";
 import { MapProps } from "#types/MapProps";
+import { getBounds } from "#utils/pathUtils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import useZoomControl from "./useZoomControl";
 
-const useShowMap = ({ height = "100vh", center, level = 1, runningPath }: MapProps) => {
+const useShowMap = ({ height = "50vh", center, level = 1, runningPath }: MapProps) => {
     const container = useRef<HTMLDivElement>(null);
     const map = useRef<kakao.maps.Map>();
     const polyLineRef = useRef<kakao.maps.Polyline>();
@@ -17,15 +18,24 @@ const useShowMap = ({ height = "100vh", center, level = 1, runningPath }: MapPro
             center: new kakao.maps.LatLng(center.lat, center.lng),
             level,
         });
+        if (!runningPath) return;
         polyLineRef.current = new kakao.maps.Polyline({
             map: map.current,
             path,
         });
         DrawPath(runningPath);
-    }, [runningPath]);
+        const pathBounds = getBounds(runningPath);
+        const sw = new kakao.maps.LatLng(pathBounds.minLat, pathBounds.minLng);
+        const ne = new kakao.maps.LatLng(pathBounds.maxLat, pathBounds.maxLng);
+        const mapBounds = new kakao.maps.LatLngBounds(sw, ne);
+        // const bounds = map.current.LatLngBounds();
+        map.current.setBounds(mapBounds);
+    }, [runningPath, map]);
+
     const getLaMaByLatLng = (point: LatLng): kakao.maps.LatLng => {
         return new kakao.maps.LatLng(point.lat, point.lng);
     };
+
     const DrawPath = useCallback(
         async (path: { lat: number; lng: number }[] | undefined) => {
             if (!path) {

--- a/client/src/pages/CourseDetail/CourseDetail.tsx
+++ b/client/src/pages/CourseDetail/CourseDetail.tsx
@@ -1,6 +1,5 @@
 import Header from "#components/Header/Header";
 import Button from "#components/Button/Button";
-import useMap from "#hooks/useMap";
 import { Content, Title } from "./CourseDetail.styles";
 import Modal from "#components/Modal/Modal";
 import { useCallback, useEffect, useState } from "react";
@@ -21,8 +20,10 @@ import useStartTimeInput from "#hooks/useStartTimeInput";
 import useMaxPplInput from "#hooks/useMaxPplInput";
 import useHttpGet from "#hooks/http/useHttpGet";
 import { InputWrapper } from "#pages/SignUp/SignUp.styles";
-import { useRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
 import { userState } from "#atoms/userState";
+import useShowMap from "#hooks/useShowMap";
+import { getMiddlePoint } from "#utils/pathUtils";
 
 const Buttons = styled.div`
     ${flexRowSpaceAround}
@@ -30,22 +31,27 @@ const Buttons = styled.div`
 `;
 
 const CourseDetail = () => {
-    const [userInfo] = useRecoilState(userState);
-
+    const userInfo = useRecoilValue(userState);
     const [courseTitle, setCourseTitle] = useState("제목");
     const [startPoint, setStartPoint] = useState("출발점");
     const [totalLength, setTotalLength] = useState(0);
     const [author, setAuthor] = useState("게시자");
+
+    const [path, setPath] = useState([]);
 
     const [title, onChangeTitle, titleError] = useInput(recruitTitleValidator);
     const { pace, onChangeMinute, onChangeSecond } = usePaceInput();
     const { startTime, onChangeStartTime } = useStartTimeInput();
     const { maxPpl, onChangeMaxPpl } = useMaxPplInput();
 
-    const { renderMap } = useMap({
-        height: `70vh`,
-        center: { lat: 33.450701, lng: 126.570667 },
-    });
+    const renderMap = useCallback(
+        useShowMap({
+            height: `70vh`,
+            center: getMiddlePoint(path),
+            runningPath: path,
+        }).renderMap,
+        [path],
+    );
 
     const checkFormValidation = () => title && maxPpl && startTime && pace;
 
@@ -84,6 +90,7 @@ const CourseDetail = () => {
             setTotalLength(response.pathLength / 1000);
             setStartPoint(response.hDong.name);
             setAuthor(response.userId);
+            setPath(JSON.parse(response.path));
         } catch {}
     }, []);
 

--- a/client/src/pages/RecruitDetail/RecruitDetail.tsx
+++ b/client/src/pages/RecruitDetail/RecruitDetail.tsx
@@ -9,6 +9,7 @@ import useHttpGet from "#hooks/http/useHttpGet";
 import { useEffect, useState, useCallback } from "react";
 import useShowMap from "#hooks/useShowMap";
 import { getPaceFormat } from "#utils/paceUtils";
+import { getMiddlePoint } from "#utils/pathUtils";
 
 const RecruitDetail = () => {
     const { id } = useParams();
@@ -33,6 +34,7 @@ const RecruitDetail = () => {
             time[1]
         }분`;
     };
+
     const onSubmitJoin = async () => {
         try {
             await post("/recruit/join", {
@@ -44,6 +46,7 @@ const RecruitDetail = () => {
             alert(error.message);
         }
     };
+
     const renderMap = useCallback(
         useShowMap({
             height: `${window.innerHeight - 307}px`,
@@ -51,29 +54,9 @@ const RecruitDetail = () => {
             runningPath: path,
             level: 5,
         }).renderMap,
-        [path, middlePoint],
+        [path],
     );
-    const getMiddlePoint = (path: { lat: number; lng: number }[]) => {
-        let minLat = 90;
-        let maxLat = -90;
-        let minLng = 180;
-        let maxLng = -180;
-        for (const point of path) {
-            if (minLat > point.lat) {
-                minLat = point.lat;
-            }
-            if (maxLat < point.lat) {
-                maxLat = point.lat;
-            }
-            if (minLng > point.lng) {
-                minLng = point.lng;
-            }
-            if (maxLng < point.lng) {
-                maxLng = point.lng;
-            }
-        }
-        return { lat: (minLat + maxLat) / 2, lng: (minLng + maxLng) / 2 };
-    };
+
     const getRecruitDetail = useCallback(async () => {
         try {
             const response = await get(`/recruit/${id}`);

--- a/client/src/types/maps/LatLngBounds.d.ts
+++ b/client/src/types/maps/LatLngBounds.d.ts
@@ -1,0 +1,5 @@
+declare namespace kakao.maps {
+    export class LatLngBounds {
+        constructor(sw: LatLng, ne: LatLng);
+    }
+}

--- a/client/src/utils/pathUtils.ts
+++ b/client/src/utils/pathUtils.ts
@@ -1,0 +1,33 @@
+export const getMiddlePoint = (path: { lat: number; lng: number }[]) => {
+    const bounds = getBounds(path);
+    return { lat: (bounds.minLat + bounds.maxLat) / 2, lng: (bounds.minLng + bounds.maxLng) / 2 };
+};
+
+export const getBounds = (path: { lat: number; lng: number }[]) => {
+    let minLat = 90;
+    let maxLat = -90;
+    let minLng = 180;
+    let maxLng = -180;
+
+    for (const point of path) {
+        if (minLat > point.lat) {
+            minLat = point.lat;
+        }
+        if (maxLat < point.lat) {
+            maxLat = point.lat;
+        }
+        if (minLng > point.lng) {
+            minLng = point.lng;
+        }
+        if (maxLng < point.lng) {
+            maxLng = point.lng;
+        }
+    }
+
+    return {
+        minLat,
+        maxLat,
+        minLng,
+        maxLng,
+    };
+};


### PR DESCRIPTION
## Feature

- 배경
코스 상세페이지 지도에 코스를 나타낸다.
- 목적
코스 상세페이지 지도에 코스를 나타낸다.
## 과정
카카오 맵 API를 활용하여 지도에 그려준 후, setBounds로 모든 코스가 지도에 들어오도록 구현한다.
## 결과 (스크린샷 등)
<img width="1413" alt="스크린샷 2022-11-29 오후 8 56 14" src="https://user-images.githubusercontent.com/97938489/204522774-06cdddb5-fa30-45cc-ab28-5160d1ccb735.png">

## 관련 issue 번호 (링크)
- #130
## 테스트 방법

## Commit
