### PR TITLE
feat: 확인 모달창 -> 모집 참여, 모집 생성, 코스 생성

### DIFF
--- a/client/src/pages/NewCourse/NewCourse.tsx
+++ b/client/src/pages/NewCourse/NewCourse.tsx
@@ -7,13 +7,13 @@ import useInput from "#hooks/useInput";
 import useLocalAPI from "#hooks/useLocalAPI";
 import getLatLngByXY from "#utils/mapUtils";
 import { PLACEHOLDER } from "#constants/placeholder";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { courseTitleValidator } from "#utils/validationUtils";
 import { RegionResponse } from "#types/Region";
 import { CourseForm } from "./NewCourse.styles";
 import useAuth from "#hooks/useAuth";
-
+import ConfirmModal from "#components/ConfirmModal/ConfirmModal";
 import { LOCAL_API_PATH } from "#types/LocalAPIType";
 //#endregion
 const img =
@@ -24,19 +24,31 @@ const NewCourse = () => {
     const query = useLocalAPI<RegionResponse>(LOCAL_API_PATH.REGION_CODE);
     const { post } = useHttpPost();
     const navigate = useNavigate();
+    const [showConfirmModal, setShowConfirmModal] = useState(false);
 
     const { renderMap, pathLength, path } = useWriteMap({
         height: `${window.innerHeight - 307}px`,
         center: { lat: 33.450701, lng: 126.570667 },
     });
 
+    const checkFormValidation = () => {
+        if (title && path.length) {
+            handleToggleConfirmModal();
+            console.log(title);
+        }
+    };
+
+    const handleToggleConfirmModal = () => {
+        setShowConfirmModal(!showConfirmModal);
+    };
+
     const onClickInsertButton = useCallback(async () => {
-        if (!title || !path.length) return;
         try {
             const { lng: x, lat: y } = getLatLngByXY(path[0]);
             const regions = await query({ x, y });
             // [0]: BCode, [1]: HCode
             const { code: hCode, region_3depth_name: name } = regions.documents[1];
+            console.log(title);
             const response: any = await post("/course", {
                 title,
                 path: path.map(getLatLngByXY),
@@ -65,10 +77,16 @@ const NewCourse = () => {
                     <span>코스명</span>
                     <Input onChange={onChangeTitle} placeholder={PLACEHOLDER.COURSE_NAME}></Input>
                 </div>
-                <Button width="fit" onClick={onClickInsertButton}>
+                <Button width="fit" onClick={checkFormValidation}>
                     코스 등록
                 </Button>
             </CourseForm>
+            <ConfirmModal
+                text="등록 하시겠습니까?"
+                showModal={showConfirmModal}
+                handleToggleModal={handleToggleConfirmModal}
+                confirmOnClick={onClickInsertButton}
+            ></ConfirmModal>
         </div>
     );
 };

--- a/client/src/pages/RecruitDetail/RecruitDetail.tsx
+++ b/client/src/pages/RecruitDetail/RecruitDetail.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import useHttpPost from "#hooks/http/useHttpPost";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import useShowMap from "#hooks/useShowMap";
 import useRecruitDetailQuery from "#hooks/queries/useRecruitDetailQuery";
 import { getMiddlePoint } from "#utils/mapUtils";
@@ -9,6 +9,7 @@ import { Content, Title } from "#pages/RecruitDetail.styles";
 import { getTimeFormat } from "#utils/stringUtils";
 import { getPaceFormat } from "#utils/paceUtils";
 import Button from "#components/Button/Button";
+import ConfirmModal from "#components/ConfirmModal/ConfirmModal";
 
 const RecruitDetail = () => {
     const { id } = useParams();
@@ -25,6 +26,11 @@ const RecruitDetail = () => {
         }).renderMap,
         [data],
     );
+
+    const [showConfirmModal, setShowConfirmModal] = useState(false);
+    const handleToggleConfirmModal = () => {
+        setShowConfirmModal(!showConfirmModal);
+    };
 
     const onSubmitJoin = useCallback(async () => {
         try {
@@ -67,10 +73,16 @@ const RecruitDetail = () => {
                         {data.currentPpl} / {data.maxPpl}
                     </p>
                 </div>
-                <Button width="fit" onClick={onSubmitJoin}>
+                <Button width="fit" onClick={handleToggleConfirmModal}>
                     참여하기
                 </Button>
             </Content>
+            <ConfirmModal
+                text="참여 하시겠습니까?"
+                showModal={showConfirmModal}
+                handleToggleModal={handleToggleConfirmModal}
+                confirmOnClick={onSubmitJoin}
+            ></ConfirmModal>
         </>
     );
 };

--- a/server/src/course/response/get-one.response.ts
+++ b/server/src/course/response/get-one.response.ts
@@ -1,0 +1,45 @@
+import { instanceToPlain, plainToInstance, Expose, Type } from "class-transformer";
+import { Course } from "src/common/entities/course.entity";
+
+class LatLng {
+    @Expose()
+    lat: number;
+
+    @Expose()
+    lng: number;
+}
+
+class HDong {
+    @Expose()
+    name: string;
+}
+
+export class CourseResponseDto {
+    @Expose()
+    id: number;
+
+    @Expose()
+    title: string;
+
+    @Expose()
+    @Type(() => LatLng)
+    path: LatLng[];
+
+    @Expose()
+    pathLength: number;
+
+    @Expose()
+    userId: string;
+
+    @Expose()
+    @Type(() => HDong)
+    hDong: HDong;
+
+    @Expose()
+    createdAt: Date;
+
+    static fromEntity(course: Course) {
+        const data = instanceToPlain(course);
+        return plainToInstance(CourseResponseDto, data, { excludeExtraneousValues: true });
+    }
+}


### PR DESCRIPTION
## Feature

- 배경
모집 게시글을 올리기 전, 모집에 참여하기 전, 코스를 생성하기 전 확인 모달창으로 재확인한다.
- 목적
모집 게시글을 올리기 전, 모집에 참여하기 전, 코스를 생성하기 전 확인 모달창으로 재확인한다.
## 과정
확인창 공통 컴포넌트를 활용한다.
## 결과 (스크린샷 등)
<img width="373" alt="스크린샷 2022-12-01 오후 1 56 14" src="https://user-images.githubusercontent.com/97938489/204975062-85c9bd51-67ee-47cf-8c17-387a2d155755.png">
<img width="376" alt="스크린샷 2022-12-01 오후 2 02 04" src="https://user-images.githubusercontent.com/97938489/204975076-146040e2-dee8-4a12-a3fc-6f4aca9f58a3.png">
<img width="370" alt="스크린샷 2022-12-01 오후 2 29 00" src="https://user-images.githubusercontent.com/97938489/204975093-18205dc0-98d6-48de-b7da-3a94cb242563.png">

## 관련 issue 번호 (링크)
#165 
## 테스트 방법

## Commit
