### PR TITLE
feat: ID 중복 체크 /  회원가입 입력 항목 추가

### DIFF
--- a/client/src/components/Input/Input.tsx
+++ b/client/src/components/Input/Input.tsx
@@ -1,19 +1,21 @@
-import { ChangeEventHandler, ReactNode } from "react";
+import { ChangeEventHandler, FocusEventHandler, ReactNode } from "react";
 import { InputWrapper } from "./Input.style";
 
 interface InputProps {
-    type?: "text" | "password" | "number";
+    type?: "text" | "password" | "number" | "checkbox";
     width?: string;
     child?: ReactNode;
     placeholder?: string;
     onChange?: ChangeEventHandler<HTMLInputElement>;
+    onBlur?: FocusEventHandler<HTMLInputElement>;
     attr?: object;
 }
 
-const Input = ({ width, type = "text", placeholder, child, onChange, attr }: InputProps) => {
+const Input = ({ width, type = "text", placeholder, child, onChange, onBlur, attr }: InputProps) => {
     return (
         <InputWrapper width={width ?? "100%"}>
             <input
+                onBlur={onBlur}
                 onChange={onChange}
                 placeholder={placeholder}
                 type={type}

--- a/client/src/constants/errorMessage.ts
+++ b/client/src/constants/errorMessage.ts
@@ -2,4 +2,5 @@ export enum ERROR {
     INVALID_MINUTE_VALUE = "1 이상 60 이하의 숫자만 입력 가능합니다.",
     INVALID_STARTTIME_VALUE = "지금으로부터 1시간 이후여야 합니다.",
     INVALID_MAXPPL_VALUE = "1명 이상 50명 이하여야 합니다.",
+    DUPLICATED_USER_ID = "현재 사용중인 아이디입니다.",
 }

--- a/client/src/constants/placeholder.ts
+++ b/client/src/constants/placeholder.ts
@@ -8,4 +8,5 @@ export enum PLACEHOLDER {
     COURSE_NAME = "코스명을 작성하세요",
     TITLE = "제목을 입력하세요",
     REGION = "읍면동 정보를 입력하세요",
+    EMAIL = "메일 주소를 입력하세요",
 }

--- a/client/src/hooks/useUserIdInput.ts
+++ b/client/src/hooks/useUserIdInput.ts
@@ -1,0 +1,30 @@
+import { ERROR } from "#constants/errorMessage";
+import { idValidator } from "#utils/validationUtils";
+import { ChangeEvent, useCallback, useState } from "react";
+import useHttpGet from "./http/useHttpGet";
+
+const useUserIdInput = () => {
+    const [userId, setUserId] = useState("");
+    const [userIdError, setUserIdError] = useState("");
+    const { get } = useHttpGet<{ statusCode: number; exists: boolean }>();
+    const onChangeUserId = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setUserIdError("");
+        const error = idValidator(e.target.value);
+        if (!error) {
+            setUserId(e.target.value);
+            return;
+        }
+        setUserId("");
+        setUserIdError(error);
+        return;
+    }, []);
+
+    const onBlurUserId = useCallback(async () => {
+        if (!userId) return;
+        const result = await get(`/user/${userId}`);
+        setUserIdError(result.exists ? ERROR.DUPLICATED_USER_ID : "");
+    }, [userId]);
+
+    return { userId, userIdError, onChangeUserId, onBlurUserId };
+};
+export default useUserIdInput;

--- a/client/src/pages/SignUp/SignUp.styles.ts
+++ b/client/src/pages/SignUp/SignUp.styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { COLOR } from "styles/color";
-import { flexRow, flexRowCenter } from "styles/flex";
+import { flexRow } from "styles/flex";
 import { fontMedium } from "styles/font";
 
 export const Logo = styled.div`

--- a/client/src/pages/SignUp/SignUp.styles.ts
+++ b/client/src/pages/SignUp/SignUp.styles.ts
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 import { COLOR } from "styles/color";
+import { flexRow, flexRowCenter } from "styles/flex";
+import { fontMedium } from "styles/font";
 
 export const Logo = styled.div`
     color: ${COLOR.BLACK};
@@ -22,12 +24,22 @@ export const InputWrapper = styled.div`
 
     span {
         color: red;
-        float: left;
         font-size: 1rem;
     }
 
     button {
         margin-top: 25px;
+    }
+`;
+
+export const CheckboxWrapper = styled.div`
+    ${flexRow};
+    align-items: center;
+
+    margin: 1rem 0 0 1rem;
+    label {
+        margin-left: 1rem;
+        ${fontMedium(COLOR.BLACK, 500)}
     }
 `;
 

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from "react";
+import React, { ChangeEventHandler, useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "#components/Header/Header";
 import Input from "#components/Input/Input";
 import Button from "#components/Button/Button";
 import useInput from "#hooks/useInput";
-import { confirmPasswordValidator, idValidator, passwordValidator } from "#utils/validationUtils";
-import { InputWrapper, Logo, OptionsWrapper } from "./SignUp.styles";
+import { confirmPasswordValidator, emailValidator, passwordValidator } from "#utils/validationUtils";
+import { CheckboxWrapper, InputWrapper, Logo, OptionsWrapper } from "./SignUp.styles";
 import { PLACEHOLDER } from "#constants/placeholder";
 import usePaceInput from "#hooks/usePaceInput";
 import PaceInput from "#components/Input/PaceInput/PaceInput";
@@ -13,19 +13,26 @@ import useHttpPost from "#hooks/http/useHttpPost";
 import { Address } from "#types/Address";
 import AddressSearchInput from "#components/Input/AddressSearchInput/AddressSearchInput";
 import PostUserBody from "#types/dto/PostUserBody";
+import useUserIdInput from "#hooks/useUserIdInput";
 
 const SignUp = () => {
-    const [userId, onChangeUserId, userIdError] = useInput(idValidator);
+    const { userId, userIdError, onChangeUserId, onBlurUserId } = useUserIdInput();
+    const [email, onChangeEmail, emailError] = useInput(emailValidator);
     const [password, onChangePassword, passwordError] = useInput(passwordValidator);
     const [region, setRegion] = useState<Address | null>(null);
     const [confirmPassword, onChangeConfirmPassword, confirmPasswordError] = useInput(
         confirmPasswordValidator(String(password)),
     );
+    const [receiveMail, setReceiveMail] = useState(false);
     const { post } = useHttpPost<null, PostUserBody>();
     const { pace, onChangeMinute, onChangeSecond } = usePaceInput();
     const navigate = useNavigate();
 
-    const checkFormValidation = () => confirmPassword && password && userId && region?.address.h_code;
+    const checkFormValidation = () => confirmPassword && password && userId && region?.address.h_code && email;
+
+    const onChangeReceiveMail: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
+        setReceiveMail(e.target.checked);
+    }, []);
 
     const onSubmitSignUp = async () => {
         if (!checkFormValidation()) return;
@@ -34,6 +41,8 @@ const SignUp = () => {
             password: password as string,
             hCode: (region && region.address.h_code) || "",
             pace: pace.minute * 60 + pace.second,
+            email: email as string,
+            receiveMail,
         };
         try {
             await post("/user", userInfo);
@@ -48,7 +57,7 @@ const SignUp = () => {
             <Header text="회원가입"></Header>
             <Logo>RunWithMe</Logo>
             <InputWrapper>
-                <Input placeholder={PLACEHOLDER.ID} type="text" onChange={onChangeUserId}></Input>
+                <Input placeholder={PLACEHOLDER.ID} type="text" onChange={onChangeUserId} onBlur={onBlurUserId} />
                 <span>{userIdError}</span>
                 <Input placeholder={PLACEHOLDER.PASSWORD} type="password" onChange={onChangePassword}></Input>
                 <span>{passwordError}</span>
@@ -60,6 +69,12 @@ const SignUp = () => {
                 <span>{confirmPasswordError}</span>
                 <PaceInput onChangeMinute={onChangeMinute} onChangeSecond={onChangeSecond}></PaceInput>
                 <AddressSearchInput setRegion={setRegion} />
+                <Input placeholder={PLACEHOLDER.EMAIL} onChange={onChangeEmail} />
+                <span>{emailError}</span>
+                <CheckboxWrapper>
+                    <input onChange={onChangeReceiveMail} type="checkbox" />
+                    <label>이벤트 및 소식 E-mail 수신 동의</label>
+                </CheckboxWrapper>
                 <Button width="fill" onClick={onSubmitSignUp}>
                     회원가입
                 </Button>

--- a/client/src/types/dto/PostUserBody.ts
+++ b/client/src/types/dto/PostUserBody.ts
@@ -3,6 +3,8 @@ interface PostUserBody {
     password: string;
     hCode: string;
     pace?: number;
+    email: string;
+    receiveMail: boolean;
 }
 
 export default PostUserBody;

--- a/client/src/utils/validationUtils.ts
+++ b/client/src/utils/validationUtils.ts
@@ -24,3 +24,9 @@ export const courseTitleValidator = (title: string) => {
 export const recruitTitleValidator = (title: string) => {
     return title.trim() ? "" : "제목을 입력하세요";
 };
+
+export const emailValidator = (email: string) => {
+    return /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i.test(email)
+        ? ""
+        : "메일 주소를 입력하세요";
+};


### PR DESCRIPTION
## Feature

- 배경
  - 메일 알림 기능을 추가하면서 유저의 메일 주소와 수신 동의 여부를 수집할 필요가 생김
- 목적
  - id 중복 체크 API 연동
  - 메일 주소와 수신 동의 여부를 수집할 필요가 생김

## 과정
- id 중복 체크 API 연동
- 회원 가입 폼에서 메일 주소와 수신 동의 여부 입력받도록 수정
## 결과 (스크린샷 등)
![image](https://user-images.githubusercontent.com/71205245/205822322-3b925b38-69fc-4782-9709-b314ebc8e2e4.png)

## 관련 issue 번호 (링크)
- #191 
## 테스트 방법

## Commit
