### PR TITLE
feat: 모집글 삭제, 참여 취소 API 구현

### DIFF
--- a/server/src/common/interceptors/http-request/http-request-body.interceptor.ts
+++ b/server/src/common/interceptors/http-request/http-request-body.interceptor.ts
@@ -14,7 +14,7 @@ export class HttpRequestBodyInterceptor implements NestInterceptor {
             try {
                 accessToken = accessToken.split("Bearer")[1].trim();
                 const { userIdx } = this.jwtService.verifyAccessToken(accessToken);
-                if (request.method === "GET") {
+                if (request.method === "GET" || request.method === "DELETE") {
                     request.params.userId = userIdx;
                 }
                 if (request.method === "POST") {

--- a/server/src/common/repositories/user_recruit.repository.ts
+++ b/server/src/common/repositories/user_recruit.repository.ts
@@ -16,9 +16,12 @@ export class UserRecruitRepository extends Repository<UserRecruit> {
         return false;
     }
     public async countCurrentPpl(recruitId: number) {
-        return await this.countBy({ recruitId });
+        return this.countBy({ recruitId });
     }
     public createUserRecruit(userRecruitEntity: UserRecruit) {
         this.save(userRecruitEntity);
+    }
+    public deleteUserRecruit(userRecruitEntity: UserRecruit) {
+        this.delete(userRecruitEntity);
     }
 }

--- a/server/src/recruit/dto/request/delete-recruit.request.ts
+++ b/server/src/recruit/dto/request/delete-recruit.request.ts
@@ -1,0 +1,21 @@
+import { Expose, Type } from "class-transformer";
+import { IsNumber } from "class-validator";
+
+export class DeleteRecruitRequestDto {
+    @Type(() => Number)
+    @IsNumber()
+    @Expose({ name: "id" })
+    private recruitId: number;
+
+    @Type(() => Number)
+    @IsNumber()
+    private userId: number;
+
+    getRecruitId() {
+        return this.recruitId;
+    }
+
+    getUserId() {
+        return this.userId;
+    }
+}

--- a/server/src/recruit/dto/request/unjoin-recruit.request.ts
+++ b/server/src/recruit/dto/request/unjoin-recruit.request.ts
@@ -1,0 +1,26 @@
+import { Expose, Type } from "class-transformer";
+import { IsNumber } from "class-validator";
+import { UserRecruit } from "../../../common/entities/user_recruit.entity";
+
+export class UnjoinRecruitRequestDto {
+    @Type(() => Number)
+    @IsNumber()
+    @Expose({ name: "id" })
+    private recruitId: number;
+
+    @Type(() => Number)
+    @IsNumber()
+    private userId: number;
+
+    getRecruitId() {
+        return this.recruitId;
+    }
+
+    getUserId() {
+        return this.userId;
+    }
+
+    toEntity() {
+        return UserRecruit.of(this.userId, this.recruitId);
+    }
+}


### PR DESCRIPTION
## Feature

- 배경
게시자의 모집글 삭제와 참여자의 참여 취소 api를 구현한다.
- 목적
1. 게시자가 자신이 올린 게시글을 삭제하기 위함
2. 참여자가 참여중인 모집에 참여취소가 가능하도록 하기 위함

## 과정
1. token으로 디코딩해서 얻은 userId와 param으로 넘어온 recruitId를 통해 요청자가 해당 모집의 게시자인지 확인
2. 트랜잭션으로 모집글 삭제 + 해당 모집에 참여중인 userRecruit 삭제

## 결과 (스크린샷 등)
생략
## 관련 issue 번호 (링크)
#208 
## 테스트 방법
### 참여 취소
` DELETE localhost:4000/recruit/:id/join`
### 모집 취소
`DELETE localhost:4000/recruit/:id`
## Commit