### PR TITLE
feat: user 엔티티 추가사항 반영 및 user와 hCode 엔티티간 관계 설정되어 있지 않던 이슈 수정

### DIFF
--- a/server/src/common/entities/h_dong.entity.ts
+++ b/server/src/common/entities/h_dong.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, OneToMany, PrimaryColumn } from "typeorm";
-import { Course } from "../entities/course.entity";
+import { Course } from "./course.entity";
+import { User } from "./user.entity";
 
 @Entity("h_dong")
 export class HDong {
@@ -11,4 +12,7 @@ export class HDong {
 
     @OneToMany(() => Course, (course) => course.hCode)
     courses: Course[];
+
+    @OneToMany(() => User, (user) => user.hCode)
+    users: User[];
 }

--- a/server/src/common/entities/user.entity.ts
+++ b/server/src/common/entities/user.entity.ts
@@ -1,7 +1,8 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, OneToMany, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from "typeorm";
 import { Course } from "./course.entity";
 import { Recruit } from "./recruit.entity";
 import { UserRecruit } from "./user_recruit.entity";
+import { HDong } from "./h_dong.entity";
 
 @Entity("user")
 export class User {
@@ -17,6 +18,11 @@ export class User {
     @Column()
     pace: number;
 
+    @Column()
+    email: string;
+
+    @ManyToOne(() => HDong, (hCode) => hCode.users, { nullable: true })
+    @JoinColumn({ name: "hCode", referencedColumnName: "code" })
     @Column({ type: "varchar", length: 10 })
     hCode: string;
 

--- a/server/src/common/entities/user.entity.ts
+++ b/server/src/common/entities/user.entity.ts
@@ -3,6 +3,7 @@ import { Course } from "./course.entity";
 import { Recruit } from "./recruit.entity";
 import { UserRecruit } from "./user_recruit.entity";
 import { HDong } from "./h_dong.entity";
+import { BooleanTransformer } from "../transformer/boolean.transformer";
 
 @Entity("user")
 export class User {
@@ -20,6 +21,14 @@ export class User {
 
     @Column()
     email: string;
+
+    @Column({
+        type: "tinyint",
+        width: 1,
+        nullable: true,
+        transformer: new BooleanTransformer(),
+    })
+    receiveMail: boolean;
 
     @ManyToOne(() => HDong, (hCode) => hCode.users, { nullable: true })
     @JoinColumn({ name: "hCode", referencedColumnName: "code" })

--- a/server/src/common/transformer/boolean.transformer.ts
+++ b/server/src/common/transformer/boolean.transformer.ts
@@ -1,0 +1,17 @@
+import { ValueTransformer } from "typeorm";
+
+export class BooleanTransformer implements ValueTransformer {
+    public from(value?: number | null): boolean | undefined {
+        if (typeof value === "undefined" || value == null) {
+            return;
+        }
+        return value ? true : false;
+    }
+
+    public to(value?: boolean | null): number | undefined {
+        if (typeof value === "undefined" || value == null) {
+            return;
+        }
+        return value ? 1 : 0;
+    }
+}


### PR DESCRIPTION
## Feature

- 배경
    - 회원가입시 이메일 필드 추가 (이메일 알림 서비스)
- 목적
    - 엔티티 파일에 이메일 컬럼 추가
    - 기존 user 엔티티와 hDong 엔티티 사이 관계 설정 

## 과정
- 엔티티 파일 수정
- booleanTransformer 추가

## 결과 (스크린샷 등)
- 생략
## 관련 issue 번호 (링크)
#212
## 테스트 방법
Postman
## Commit
